### PR TITLE
Autoboot channel when launching sign_patcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ export OBJCOPY	:=	$(PREFIX)objcopy
 # SOURCES is a list of directories containing source code
 # INCLUDES is a list of directories containing extra header files
 #---------------------------------------------------------------------------------
-TARGET		:=	sign_patcher
+TARGET		:=	sign_c2w_patcher
 BUILD		:=	build
 BUILD_DBG	:=	$(TARGET)_dbg
 SOURCES		:=	src \

--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+This app will apply signature patches and also redirect cafe2wii to be loaded from any wii vc title you boot up, this allows for easy cafe2wii patches without having to modify the actual system title.

--- a/src/main.c
+++ b/src/main.c
@@ -314,7 +314,8 @@ int Menu_Main(void)
     // in case we are not in mii maker but in system menu we start the installation
     if (currenTitleId != 0x000500101004A200 && // mii maker eur
         currenTitleId != 0x000500101004A100 && // mii maker usa
-        currenTitleId != 0x000500101004A000)   // mii maker jpn
+        currenTitleId != 0x000500101004A000 && // mii maker jpn
+        currenTitleId != 0x0005000013374842)   // HBL channel
     {
         return EXIT_RELAUNCH_ON_LOAD;
     }


### PR DESCRIPTION
I came across this mod of SDcafiine https://gamebanana.com/threads/210597 that allows one to autoboot a channel as soon as they launch SDcafiine, now I'd ask if he could take a look at your work here and do the same for sign_patcher so we can immediately overclock emulator channels we've insallted like WiiSXr or Wii64 Rice, but he seems to be inactive for 2 years now, and I can't locate him anywhere else.  All the same, you definitely seem to understand the Wii U very well, so perhaps it makes all the more sense for me to go directly to you. 

Could you modify sign_c2_patcher to function like his mod of SDcafiine, where if we include a .txt file in it's directory, we can have it automatically launch a channel of our choosing after applying the overclock patch?  I feel like this could be really helpful.